### PR TITLE
Allow alephium:v1.4.6 image

### DIFF
--- a/helpers/repositories.json
+++ b/helpers/repositories.json
@@ -406,5 +406,6 @@
    "ipfs/ipfs-cluster",
    "modernglobal/mintit-fe",
    "wanchain/client-go:latest",
-   "wanchain/client-go:3.0.0"
+   "wanchain/client-go:3.0.0",
+   "touilleio/alephium-standalone:v1.4.6"
 ]


### PR DESCRIPTION
Allow alephium:v1.4.6 image, wrapped to be standalone and compatible with Flux.
[Alephium](https://alephium.org) is a sharded L1 blockchain scaling and enhancing PoW & UTXO.